### PR TITLE
Update PyDevRemoteDebug.py

### DIFF
--- a/PyDevRemoteDebug/PyDevRemoteDebug.py
+++ b/PyDevRemoteDebug/PyDevRemoteDebug.py
@@ -572,7 +572,13 @@ class PyDevRemoteDebugLogic(ScriptedLoadableModuleLogic):
         import pydevd
       except ImportError:
         return False
-      return pydevd.connected
+      # return attribute depending on which version of pydevd.py is being used
+      if hasattr(pydevd, '_debugger_setup'):
+        return pydevd._debugger_setup     # updated PyDev
+      elif hasattr(pydevd, 'connected'):
+        return pydevd.connected           # older version
+      else:
+        return False
       
   def isCorrectVisualStudioDebuggerVersion(self):
     import ptvsd


### PR DESCRIPTION
PyDev has updated the pydevd.py script to use the attribute '_debugger_setup' to reflect connection with the client and the host.
Previous versions of PyDev used the attribute 'connected'. 
This change occurred somewhere between versions PyDev 7.0.3 and 7.3.0